### PR TITLE
Table Management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,12 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'themoviedb'
 gem 'devise'
 
-# use roo for parsing excel
+# Use roo for parsing excel
 gem "roo", "~> 2.8.0"
+
+# Use will_paginate for table pagination
+gem 'will_paginate', '~> 3.1.1'
+gem 'will_paginate-bootstrap' 
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,9 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    will_paginate (3.1.8)
+    will_paginate-bootstrap (1.0.2)
+      will_paginate (>= 3.0.3)
 
 PLATFORMS
   ruby
@@ -256,6 +259,8 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  will_paginate (~> 3.1.1)
+  will_paginate-bootstrap
 
 RUBY VERSION
    ruby 2.6.4p104

--- a/app/assets/javascripts/paginator.js
+++ b/app/assets/javascripts/paginator.js
@@ -1,0 +1,19 @@
+$('body').on('click', '[data-go-to-page]', function(){
+  var input_text = '<input type="text" name="go_to_page" size="4">';
+  var span = $(this).find('span');
+  span.html(input_text);
+  $("[name='go_to_page']").focus();
+});
+
+$('body').on('keypress', 'input[name="go_to_page"]', function (e) {
+  new_page = $(this).val();
+  var charCode = (e.which) ? e.which : e.keyCode;
+  if (charCode == 13 && new_page > 0) {
+      $.ajax({
+          dataType: "script",
+          url: window.location.href,
+          data: {page: new_page}
+      });
+      $(this).parent().html('&hellip;');
+  }
+});

--- a/app/assets/stylesheets/default.css
+++ b/app/assets/stylesheets/default.css
@@ -54,3 +54,50 @@ table#venues th.hilite {
   color: white;
   text-decoration: none;
 }
+
+.digg_pagination {
+  background: white;
+  cursor: default;
+  /* self-clearing method: */ }
+  .digg_pagination a, .digg_pagination span, .digg_pagination em {
+    padding: 0.2em 0.5em;
+    display: block;
+    float: left;
+    margin-right: 1px; }
+  .digg_pagination .disabled {
+    color: #999999;
+    border: 1px solid #dddddd; }
+  .digg_pagination .current {
+    font-style: normal;
+    font-weight: bold;
+    background: #2e6ab1;
+    color: white;
+    border: 1px solid #2e6ab1; }
+  .digg_pagination a {
+    text-decoration: none;
+    color: #105cb6;
+    border: 1px solid #9aafe5; }
+    .digg_pagination a:hover, .digg_pagination a:focus {
+      color: #000033;
+      border-color: #000033; }
+  .digg_pagination .page_info {
+    background: #2e6ab1;
+    color: white;
+    padding: 0.4em 0.6em;
+    width: 22em;
+    margin-bottom: 0.3em;
+    text-align: center; }
+    .digg_pagination .page_info b {
+      color: #000033;
+      background: #6aa6ed;
+      padding: 0.1em 0.25em; }
+  .digg_pagination:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden; }
+  * html .digg_pagination {
+    height: 1%; }
+  *:first-child + html .digg_pagination {
+    overflow: hidden; }

--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -40,8 +40,7 @@ class VenuesController < ApplicationController
         minval = @ratings.min
         maxval = @ratings.max
 
-
-        @venues = Venue.where("rating >= ? AND rating <= ?", minval,maxval).order(sort_by)
+        @venues = Venue.where("rating >= ? AND rating <= ?", minval,maxval).order(sort_by).paginate(page: params[:page], per_page: 10)
 
       #redirect_to venues_path
       return

--- a/app/helpers/remote_link_pagination_helper.rb
+++ b/app/helpers/remote_link_pagination_helper.rb
@@ -1,0 +1,12 @@
+module RemoteLinkPaginationHelper
+  class LinkRenderer < BootstrapPagination::Rails
+    def link(text, target, attributes = {})
+      attributes['data-remote'] = true
+      super
+    end
+
+    def gap
+      tag :li, tag(:span, '&hellip;', class: 'gap'), 'data-go-to-page': true
+    end
+  end
+end

--- a/app/views/venues/index.html.haml
+++ b/app/views/venues/index.html.haml
@@ -21,7 +21,7 @@
       - @venues.each do |venue|
         %tr
           %td= venue.venue_name
-          %td= venue.rating
+          %td= venue.rating.round(0)
           %td= venue.location
           %td= venue.season
           %td= link_to "More about #{venue.venue_name}", venue_path(venue)

--- a/app/views/venues/index.html.haml
+++ b/app/views/venues/index.html.haml
@@ -26,6 +26,9 @@
 
   = link_to 'Add new venue', new_venue_path, :class => "link_button"
 
+  .text-center
+    = will_paginate @venues, renderer: BootstrapPagination::Rails
+
 %br
 %div.container
   %h3{:style => "color:#235789;"} Recent Activity

--- a/app/views/venues/index.html.haml
+++ b/app/views/venues/index.html.haml
@@ -15,6 +15,7 @@
         %th{class: @table_header}= link_to "Venue Name", venues_path(:sort => "venue_name"), :id => "venue_name_header"
         %th Rating
         %th{class: @location_header}= link_to "Location", venues_path(:sort => "location"), :id => "location_header"
+        %th Season
         %th More Info
     %tbody
       - @venues.each do |venue|
@@ -22,6 +23,7 @@
           %td= venue.venue_name
           %td= venue.rating
           %td= venue.location
+          %td= venue.season
           %td= link_to "More about #{venue.venue_name}", venue_path(venue)
   = link_to 'Add new venue', new_venue_path, :class => "link_button", :style => "border: 3px solid black; padding: 5px;"
   %br
@@ -32,11 +34,11 @@
     = will_paginate @venues, :container => false
 
 %br
-%div.container
+%div.container#Activity
   %h3{:style => "color:#235789;"} Recent Activity
   %p TODO: Populate with recent reviews
 
 %br
-%div.container
+%div.container#Categories
   %h3{:style => "color:#235789;"} Browse Events by Category
   %p TODO: Populate with squares, allow one to choose by filters

--- a/app/views/venues/index.html.haml
+++ b/app/views/venues/index.html.haml
@@ -23,11 +23,13 @@
           %td= venue.rating
           %td= venue.location
           %td= link_to "More about #{venue.venue_name}", venue_path(venue)
+  = link_to 'Add new venue', new_venue_path, :class => "link_button", :style => "border: 3px solid black; padding: 5px;"
+  %br
 
-  = link_to 'Add new venue', new_venue_path, :class => "link_button"
-
-  .text-center
-    = will_paginate @venues, renderer: BootstrapPagination::Rails
+  %div{:class => @digg_pagination, :style => "margin:auto; width:50%; text-align:center;"}
+    %div{:class => @page_info}
+      = page_entries_info @venues
+    = will_paginate @venues, :container => false
 
 %br
 %div.container

--- a/app/views/venues/show.html.haml
+++ b/app/views/venues/show.html.haml
@@ -2,17 +2,38 @@
 
 %h4 Details about
 %h2{:style => "color:#235789;"} #{@venue.venue_name}
-%p Rated #{@venue.rating}/5 <br> Located in #{@venue.location}
 
+Rated #{@venue.rating}/5 <br>
+- if @venue.season.present?
+  Season: #{@venue.season} <br>
+- if @venue.location.present?
+  Located in
+- if @venue.county.present?
+  #{@venue.county} County,
+- if @venue.location.present?
+  #{@venue.location}
+
+%br
+%br
 %h4 Description
 
 %p#description= @venue.description
 
+- if @venue.ptype.present? || @venue.jtype.present?
+  This event has been categorized under
+  - if @venue.ptype.present?
+    #{@venue.ptype}
+  - if @venue.ptype.present?
+    , #{@venue.jtype}
+
+%br
+%br
 %h4 External Links
 
 %p#links= @venue.link
 
-<br>
+- if @venue.name.present?
+  %p This event was added by #{@venue.name}
 <hr>
 
 = link_to 'Delete Event', venue_path(@venue), :method => :delete, :confirm => 'Are you sure?', :class => 'link_button'

--- a/app/views/venues/show.html.haml
+++ b/app/views/venues/show.html.haml
@@ -8,6 +8,10 @@
 
 %p#description= @venue.description
 
+%h4 External Links
+
+%p#links= @venue.link
+
 <br>
 <hr>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,6 @@ module Venues
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,6 @@ xlsx = Roo::Spreadsheet.open path
 
 xlsx.each(venue_name: "DRAFT VENUE LIST", location:	"Location", name:	"Person who added (name)", county: "County", ptype:	"P Type", jtype:	"J Type", season: "Season (Y/N/S)", link:	"Hyperlink") do |venue|
   venue = venue.merge({rating: 1 + rand(5)})
-  puts venue
+  # puts venue
   Venue.create(venue)
 end


### PR DESCRIPTION
This PR adds table pagination so that when venues are filtered, the venues are displayed 10 at a time with the option to visit previous and next pages.

This PR also adds all the venue data to be displayed in the show page under the venue's views.

Last but not least, the table with index now has a season column.

It's worth noting that since the original venue data does not include any ratings at all, the ratings assigned to each event is randomly generated for display purposes now. This should be rectified when actual ratings can be provided by the NONO team.